### PR TITLE
fix: ensure create triggers are registered with a name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 setup-ci-env:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.55.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v1.63.1
 
 validate-ci:
 	go generate

--- a/pkg/conditions/setter.go
+++ b/pkg/conditions/setter.go
@@ -96,7 +96,6 @@ func ErrorMiddleware() router.Middleware {
 					Message:            logErr.Error(),
 				})
 				resp.Attributes()["_errormiddleware:errored"] = true
-				resp.DisablePrune()
 				return nil
 			}
 

--- a/pkg/router/client.go
+++ b/pkg/router/client.go
@@ -74,9 +74,17 @@ func (w *writer) Update(ctx context.Context, obj kclient.Object, opts ...kclient
 	return w.client.Update(ctx, obj, opts...)
 }
 
-func (w *writer) Create(ctx context.Context, obj kclient.Object, opts ...kclient.CreateOption) error {
-	if err := w.registry.Watch(obj, obj.GetNamespace(), obj.GetName(), nil, nil); err != nil {
-		return err
+func (w *writer) Create(ctx context.Context, obj kclient.Object, opts ...kclient.CreateOption) (err error) {
+	if obj.GetName() == "" {
+		defer func() {
+			if err != nil {
+				err = w.registry.Watch(obj, obj.GetNamespace(), obj.GetName(), nil, nil)
+			}
+		}()
+	} else {
+		if err = w.registry.Watch(obj, obj.GetNamespace(), obj.GetName(), nil, nil); err != nil {
+			return err
+		}
 	}
 	return w.client.Create(ctx, obj, opts...)
 }

--- a/pkg/runtime/clients.go
+++ b/pkg/runtime/clients.go
@@ -60,9 +60,9 @@ func NewRuntimeWithConfigs(defaultConfig Config, apiGroupConfigs map[string]Conf
 
 	factory := NewSharedControllerFactory(aggUncachedClient, aggCache, &SharedControllerFactoryOptions{
 		// In baaah this is only invoked when a key fails to process
-		DefaultRateLimiter: workqueue.NewMaxOfRateLimiter(
+		DefaultRateLimiter: workqueue.NewTypedMaxOfRateLimiter(
 			// This will go .5, 1, 2, 4, 8 seconds, etc up until 15 minutes
-			workqueue.NewItemExponentialFailureRateLimiter(500*time.Millisecond, 15*time.Minute),
+			workqueue.NewTypedItemExponentialFailureRateLimiter[any](500*time.Millisecond, 15*time.Minute),
 		),
 	})
 

--- a/pkg/runtime/sharedcontrollerfactory.go
+++ b/pkg/runtime/sharedcontrollerfactory.go
@@ -16,10 +16,10 @@ type SharedControllerFactory interface {
 }
 
 type SharedControllerFactoryOptions struct {
-	DefaultRateLimiter workqueue.RateLimiter
+	DefaultRateLimiter workqueue.TypedRateLimiter[any]
 	DefaultWorkers     int
 
-	KindRateLimiter map[schema.GroupVersionKind]workqueue.RateLimiter
+	KindRateLimiter map[schema.GroupVersionKind]workqueue.TypedRateLimiter[any]
 	KindWorkers     map[schema.GroupVersionKind]int
 }
 
@@ -32,9 +32,9 @@ type sharedControllerFactory struct {
 	client       kclient.Client
 	controllers  map[schema.GroupVersionKind]*sharedController
 
-	rateLimiter     workqueue.RateLimiter
+	rateLimiter     workqueue.TypedRateLimiter[any]
 	workers         int
-	kindRateLimiter map[schema.GroupVersionKind]workqueue.RateLimiter
+	kindRateLimiter map[schema.GroupVersionKind]workqueue.TypedRateLimiter[any]
 	kindWorkers     map[schema.GroupVersionKind]int
 }
 


### PR DESCRIPTION
If a create comes through with no name set (so a generated name is set), then we defer the trigger so the trigger is created with the correct name.