### PR TITLE
enhance: expose GVK-based threadiness to top-level router

### DIFF
--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -30,7 +30,7 @@ type ElectionConfig struct {
 
 func NewDefaultElectionConfig(namespace, name string, cfg *rest.Config) *ElectionConfig {
 	ttl := defaultLeaderTTL
-	if os.Getenv("BAAAH_DEV_MODE") != "" {
+	if os.Getenv("NAH_DEV_MODE") != "" {
 		ttl = devLeaderTTL
 	}
 	return &ElectionConfig{

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -17,13 +17,13 @@ var (
 		//log.Printf("INFO: "+message+"\n", obj...)
 	}
 	Warnf = func(message string, obj ...interface{}) {
-		log.Printf("WARN [BAAAH]: "+message+"\n", obj...)
+		log.Printf("WARN [NAH]: "+message+"\n", obj...)
 	}
 	Errorf = func(message string, obj ...interface{}) {
-		log.Printf("ERROR[BAAAH]: "+message+"\n", obj...)
+		log.Printf("ERROR[NAH]: "+message+"\n", obj...)
 	}
 	Fatalf = func(message string, obj ...interface{}) {
-		log.Fatalf("FATAL[BAAAH]: "+message+"\n", obj...)
+		log.Fatalf("FATAL[NAH]: "+message+"\n", obj...)
 	}
 	Debugf = func(message string, obj ...interface{}) {
 		//log.Printf("DEBUG: "+message+"\n", obj...)

--- a/pkg/runtime/backend.go
+++ b/pkg/runtime/backend.go
@@ -24,7 +24,7 @@ import (
 var DefaultThreadiness = 5
 
 func init() {
-	i, _ := strconv.Atoi(os.Getenv("BAAAH_THREADINESS"))
+	i, _ := strconv.Atoi(os.Getenv("NAH_THREADINESS"))
 	if i > 0 {
 		DefaultThreadiness = i
 	}
@@ -67,7 +67,7 @@ func (b *Backend) start(ctx context.Context, preloadOnly bool) (err error) {
 	if preloadOnly {
 		err = b.cacheFactory.Preload(ctx)
 	} else {
-		err = b.cacheFactory.Start(ctx, DefaultThreadiness)
+		err = b.cacheFactory.Start(ctx)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
This allows callers to set the threadiness based on GVKs.