### PR TITLE
enhance: start worker goroutines on demand

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -13,7 +13,7 @@ import (
 type Callback func(gvk schema.GroupVersionKind, key string, obj runtime.Object) (runtime.Object, error)
 
 type Trigger interface {
-	Trigger(gvk schema.GroupVersionKind, key string, delay time.Duration) error
+	Trigger(ctx context.Context, gvk schema.GroupVersionKind, key string, delay time.Duration) error
 }
 
 type Watcher interface {

--- a/pkg/router/handler.go
+++ b/pkg/router/handler.go
@@ -233,7 +233,7 @@ func (m *HandlerSet) checkDelay(gvk schema.GroupVersionKind, key string) bool {
 			m.limiterLock.Lock()
 			defer m.limiterLock.Unlock()
 			delete(m.waiting, lKey)
-			_ = m.backend.Trigger(gvk, ReplayPrefix+key, 0)
+			_ = m.backend.Trigger(m.ctx, gvk, ReplayPrefix+key, 0)
 		}()
 		return false
 	}
@@ -341,7 +341,7 @@ func (m *HandlerSet) handle(gvk schema.GroupVersionKind, key string, unmodifiedO
 		req.Object = newObj
 
 		if resp.delay > 0 {
-			if err := m.backend.Trigger(gvk, key, resp.delay); err != nil {
+			if err := m.backend.Trigger(m.ctx, gvk, key, resp.delay); err != nil {
 				return nil, err
 			}
 		}

--- a/pkg/router/trigger.go
+++ b/pkg/router/trigger.go
@@ -44,7 +44,7 @@ func (m *triggers) invokeTriggers(req Request) {
 		for _, matcher := range matchers {
 			if matcher.Match(req.Namespace, req.Name, req.Object) {
 				log.Debugf("Triggering [%s] [%v] from [%s] [%v]", et.key, et.gvk, req.Key, req.GVK)
-				_ = m.trigger.Trigger(et.gvk, et.key, 0)
+				_ = m.trigger.Trigger(req.Ctx, et.gvk, et.key, 0)
 				break
 			}
 		}
@@ -133,7 +133,7 @@ func (m *triggers) UnregisterAndTrigger(req Request) {
 				}
 				if targetGVK == req.GVK && mt.Match(req.Namespace, req.Name, req.Object) {
 					log.Debugf("Triggering [%s] [%v] from [%s] [%v] on delete", target.key, target.gvk, req.Key, req.GVK)
-					_ = m.trigger.Trigger(target.gvk, target.key, 0)
+					_ = m.trigger.Trigger(req.Ctx, target.gvk, target.key, 0)
 				}
 			}
 		}

--- a/pkg/runtime/backend.go
+++ b/pkg/runtime/backend.go
@@ -82,8 +82,8 @@ func (b *Backend) start(ctx context.Context, preloadOnly bool) (err error) {
 	return nil
 }
 
-func (b *Backend) Trigger(gvk schema.GroupVersionKind, key string, delay time.Duration) error {
-	controller, err := b.cacheFactory.ForKind(gvk)
+func (b *Backend) Trigger(ctx context.Context, gvk schema.GroupVersionKind, key string, delay time.Duration) error {
+	controller, err := b.cacheFactory.ForKind(ctx, gvk)
 	if err != nil {
 		return err
 	}
@@ -138,7 +138,7 @@ func (b *Backend) addIndexer(ctx context.Context, gvk schema.GroupVersionKind) e
 }
 
 func (b *Backend) Watcher(ctx context.Context, gvk schema.GroupVersionKind, name string, cb backend.Callback) error {
-	c, err := b.cacheFactory.ForKind(gvk)
+	c, err := b.cacheFactory.ForKind(ctx, gvk)
 	if err != nil {
 		return err
 	}

--- a/pkg/runtime/clients.go
+++ b/pkg/runtime/clients.go
@@ -19,7 +19,8 @@ type Runtime struct {
 
 type Config struct {
 	GroupConfig
-	GVKThreadiness map[schema.GroupVersionKind]int
+	GVKThreadiness    map[schema.GroupVersionKind]int
+	GVKQueueSplitters map[schema.GroupVersionKind]WorkerQueueSplitter
 }
 
 type GroupConfig struct {
@@ -69,7 +70,8 @@ func NewRuntimeWithConfigs(defaultConfig Config, apiGroupConfigs map[string]Grou
 	aggCache := multi.NewCache(scheme, theCache, caches)
 
 	factory := NewSharedControllerFactory(aggUncachedClient, aggCache, &SharedControllerFactoryOptions{
-		KindWorkers: defaultConfig.GVKThreadiness,
+		KindWorkers:       defaultConfig.GVKThreadiness,
+		KindQueueSplitter: defaultConfig.GVKQueueSplitters,
 		// In nah this is only invoked when a key fails to process
 		DefaultRateLimiter: workqueue.NewTypedMaxOfRateLimiter(
 			// This will go .5, 1, 2, 4, 8 seconds, etc up until 15 minutes


### PR DESCRIPTION
Instead of having a bunch of waiting goroutines, this change will introduce one goroutine per type that waits for new tasks. That goroutine will spin up new goroutines, up to the desired limit, to handle tasks as they come in.

Issue: https://github.com/obot-platform/obot/issues/1694