### PR TITLE
enhance: add enqueue key with delay

### DIFF
--- a/pkg/router/handler.go
+++ b/pkg/router/handler.go
@@ -327,7 +327,7 @@ func (m *HandlerSet) handle(gvk schema.GroupVersionKind, key string, unmodifiedO
 	if unmodifiedObject == nil {
 		// A nil object here means that the object was deleted, so unregister the triggers
 		m.triggers.UnregisterAndTrigger(req)
-	} else {
+	} else if !req.FromTrigger {
 		m.triggers.Trigger(req)
 	}
 

--- a/pkg/router/trigger.go
+++ b/pkg/router/trigger.go
@@ -105,9 +105,7 @@ func (m *triggers) shouldAddTrigger(gvk schema.GroupVersionKind, key string, tar
 }
 
 func (m *triggers) Trigger(req Request) {
-	if !req.FromTrigger {
-		m.invokeTriggers(req)
-	}
+	m.invokeTriggers(req)
 }
 
 func (m *triggers) Register(sourceGVK schema.GroupVersionKind, key string, obj runtime.Object, namespace, name string, selector labels.Selector, fields fields.Selector) (schema.GroupVersionKind, bool, error) {

--- a/pkg/runtime/backend.go
+++ b/pkg/runtime/backend.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -87,16 +86,8 @@ func (b *Backend) Trigger(ctx context.Context, gvk schema.GroupVersionKind, key 
 	if err != nil {
 		return err
 	}
-	if delay > 0 {
-		ns, name, ok := strings.Cut(key, "/")
-		if ok {
-			controller.EnqueueAfter(ns, name, delay)
-		} else {
-			controller.EnqueueAfter("", key, delay)
-		}
-	} else {
-		controller.EnqueueKey(router.TriggerPrefix + key)
-	}
+
+	controller.EnqueueKeyAfter(router.TriggerPrefix+key, delay)
 	return nil
 }
 

--- a/pkg/runtime/errorcontroller.go
+++ b/pkg/runtime/errorcontroller.go
@@ -21,6 +21,9 @@ func (n *errorController) Enqueue(namespace, name string) {
 func (n *errorController) EnqueueAfter(namespace, name string, delay time.Duration) {
 }
 
+func (n *errorController) EnqueueKeyAfter(key string, delay time.Duration) {
+}
+
 func (n *errorController) EnqueueKey(key string) {
 }
 

--- a/pkg/runtime/sharedcontroller.go
+++ b/pkg/runtime/sharedcontroller.go
@@ -53,6 +53,10 @@ func (s *sharedController) EnqueueAfter(namespace, name string, delay time.Durat
 	s.initController().EnqueueAfter(namespace, name, delay)
 }
 
+func (s *sharedController) EnqueueKeyAfter(key string, delay time.Duration) {
+	s.initController().EnqueueKeyAfter(key, delay)
+}
+
 func (s *sharedController) EnqueueKey(key string) {
 	s.initController().EnqueueKey(key)
 }


### PR DESCRIPTION
If a user uses resp.RetryAfter in a handler, the object's key is enqueued
without the trigger designation. That means, that all triggers for the object
will be invoked regardless of whether the object changes when it goes through
the handlers. This is not the desired behavior. If the object doesn't change,
then the triggers should not be invoked.

This change adds an EnqueueKeyWithDelay function that achieves this desired
behavior.