### PR TITLE
  Make nah tracing env-only and default off

### DIFF
--- a/pkg/router/handler.go
+++ b/pkg/router/handler.go
@@ -34,7 +34,7 @@ type HandlerSet struct {
 	name     string
 	scheme   *runtime.Scheme
 	backend  backend.Backend
-	tracing  tracing.Instrumentation
+	tracing  tracing.Tracing
 	handlers handlers
 	triggers triggers
 	save     save
@@ -55,15 +55,15 @@ type limiterKey struct {
 }
 
 func NewHandlerSet(name string, scheme *runtime.Scheme, backend backend.Backend) *HandlerSet {
-	instrumentation := tracing.NewInstrumentation("nah/router", "")
+	otelTracing := tracing.New("nah/router", "")
 	hs := &HandlerSet{
 		name:    name,
 		scheme:  scheme,
 		backend: backend,
-		tracing: instrumentation,
+		tracing: otelTracing,
 		handlers: handlers{
-			handlers:        map[schema.GroupVersionKind][]handler{},
-			instrumentation: instrumentation,
+			handlers: map[schema.GroupVersionKind][]handler{},
+			tracing:  otelTracing,
 		},
 		triggers: triggers{
 			trigger:     backend,
@@ -74,7 +74,7 @@ func NewHandlerSet(name string, scheme *runtime.Scheme, backend backend.Backend)
 		save: save{
 			cache:   backend,
 			client:  backend,
-			tracing: instrumentation,
+			tracing: otelTracing,
 		},
 		watching: map[schema.GroupVersionKind]bool{},
 	}

--- a/pkg/router/handler.go
+++ b/pkg/router/handler.go
@@ -11,7 +11,7 @@ import (
 	"github.com/obot-platform/nah/pkg/backend"
 	"github.com/obot-platform/nah/pkg/log"
 	"github.com/obot-platform/nah/pkg/merr"
-	"go.opentelemetry.io/otel"
+	"github.com/obot-platform/nah/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/maps"
@@ -29,13 +29,12 @@ const (
 	ReplayPrefix  = "_r "
 )
 
-var tracer = otel.Tracer("nah/router")
-
 type HandlerSet struct {
 	ctx      context.Context
 	name     string
 	scheme   *runtime.Scheme
 	backend  backend.Backend
+	tracing  tracing.Instrumentation
 	handlers handlers
 	triggers triggers
 	save     save
@@ -56,12 +55,15 @@ type limiterKey struct {
 }
 
 func NewHandlerSet(name string, scheme *runtime.Scheme, backend backend.Backend) *HandlerSet {
+	instrumentation := tracing.NewInstrumentation("nah/router", "")
 	hs := &HandlerSet{
 		name:    name,
 		scheme:  scheme,
 		backend: backend,
+		tracing: instrumentation,
 		handlers: handlers{
-			handlers: map[schema.GroupVersionKind][]handler{},
+			handlers:        map[schema.GroupVersionKind][]handler{},
+			instrumentation: instrumentation,
 		},
 		triggers: triggers{
 			trigger:     backend,
@@ -70,8 +72,9 @@ func NewHandlerSet(name string, scheme *runtime.Scheme, backend backend.Backend)
 			scheme:      scheme,
 		},
 		save: save{
-			cache:  backend,
-			client: backend,
+			cache:   backend,
+			client:  backend,
+			tracing: instrumentation,
 		},
 		watching: map[schema.GroupVersionKind]bool{},
 	}
@@ -253,7 +256,7 @@ func (m *HandlerSet) forgetBackoff(gvk schema.GroupVersionKind, key string) {
 }
 
 func (m *HandlerSet) onChange(ctx context.Context, gvk schema.GroupVersionKind, key string, runtimeObject runtime.Object) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, "onChange", trace.WithAttributes(attribute.String("key", key)), trace.WithAttributes(attribute.String("gvk", gvk.String())))
+	ctx, span := m.tracing.Start(ctx, "onChange", trace.WithAttributes(attribute.String("key", key)), trace.WithAttributes(attribute.String("gvk", gvk.String())))
 	defer span.End()
 
 	fromTrigger := false
@@ -332,7 +335,7 @@ func (m *HandlerSet) handle(ctx context.Context, gvk schema.GroupVersionKind, ke
 		}
 	}
 
-	_, span := tracer.Start(ctx, "trigger", trace.WithAttributes(attribute.String("key", key), attribute.String("gvk", gvk.String()), attribute.Bool("unregister", unmodifiedObject == nil)))
+	_, span := m.tracing.StartLevel(ctx, tracing.LevelVerbose, "trigger", trace.WithAttributes(attribute.String("key", key), attribute.String("gvk", gvk.String()), attribute.Bool("unregister", unmodifiedObject == nil)))
 	if unmodifiedObject == nil {
 		// A nil object here means that the object was deleted, so unregister the triggers
 		m.triggers.UnregisterAndTrigger(req)

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -4,14 +4,16 @@ import (
 	"sync"
 
 	"github.com/obot-platform/nah/pkg/merr"
+	"github.com/obot-platform/nah/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type handlers struct {
-	lock     sync.RWMutex
-	handlers map[schema.GroupVersionKind][]handler
+	lock            sync.RWMutex
+	handlers        map[schema.GroupVersionKind][]handler
+	instrumentation tracing.Instrumentation
 }
 
 func (h *handlers) GVKs() (result []schema.GroupVersionKind) {
@@ -25,7 +27,7 @@ func (h *handlers) AddHandler(name string, gvk schema.GroupVersionKind, hd Handl
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	h.handlers[gvk] = append(h.handlers[gvk], handler{name: name, h: hd})
+	h.handlers[gvk] = append(h.handlers[gvk], handler{name: name, h: hd, instrumentation: h.instrumentation})
 }
 
 func (h *handlers) Handles(req Request) bool {
@@ -52,12 +54,13 @@ func (h *handlers) Handle(req Request, resp *response) error {
 }
 
 type handler struct {
-	name string
-	h    Handler
+	name            string
+	h               Handler
+	instrumentation tracing.Instrumentation
 }
 
 func (h *handler) handle(req Request, resp *response) error {
-	ctx, span := tracer.Start(req.Ctx, "handlerSetHandle", trace.WithAttributes(
+	ctx, span := h.instrumentation.Start(req.Ctx, "handlerSetHandle", trace.WithAttributes(
 		attribute.String("gvk", req.GVK.String()),
 		attribute.String("namespace", req.Namespace),
 		attribute.String("name", req.Name),

--- a/pkg/router/handlers.go
+++ b/pkg/router/handlers.go
@@ -11,9 +11,9 @@ import (
 )
 
 type handlers struct {
-	lock            sync.RWMutex
-	handlers        map[schema.GroupVersionKind][]handler
-	instrumentation tracing.Instrumentation
+	lock     sync.RWMutex
+	handlers map[schema.GroupVersionKind][]handler
+	tracing  tracing.Tracing
 }
 
 func (h *handlers) GVKs() (result []schema.GroupVersionKind) {
@@ -27,7 +27,7 @@ func (h *handlers) AddHandler(name string, gvk schema.GroupVersionKind, hd Handl
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	h.handlers[gvk] = append(h.handlers[gvk], handler{name: name, h: hd, instrumentation: h.instrumentation})
+	h.handlers[gvk] = append(h.handlers[gvk], handler{name: name, h: hd, tracing: h.tracing})
 }
 
 func (h *handlers) Handles(req Request) bool {
@@ -54,13 +54,13 @@ func (h *handlers) Handle(req Request, resp *response) error {
 }
 
 type handler struct {
-	name            string
-	h               Handler
-	instrumentation tracing.Instrumentation
+	name    string
+	h       Handler
+	tracing tracing.Tracing
 }
 
 func (h *handler) handle(req Request, resp *response) error {
-	ctx, span := h.instrumentation.Start(req.Ctx, "handlerSetHandle", trace.WithAttributes(
+	ctx, span := h.tracing.Start(req.Ctx, "handlerSetHandle", trace.WithAttributes(
 		attribute.String("gvk", req.GVK.String()),
 		attribute.String("namespace", req.Namespace),
 		attribute.String("name", req.Name),

--- a/pkg/router/save.go
+++ b/pkg/router/save.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/obot-platform/nah/pkg/backend"
+	"github.com/obot-platform/nah/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -12,12 +13,13 @@ import (
 )
 
 type save struct {
-	cache  backend.CacheFactory
-	client kclient.Client
+	cache   backend.CacheFactory
+	client  kclient.Client
+	tracing tracing.Instrumentation
 }
 
 func (s *save) save(unmodified runtime.Object, req Request) (kclient.Object, error) {
-	ctx, span := tracer.Start(req.Ctx, "save", trace.WithAttributes(attribute.String("key", req.Key), attribute.String("gvk", req.GVK.String())))
+	ctx, span := s.tracing.StartLevel(req.Ctx, tracing.LevelVerbose, "save", trace.WithAttributes(attribute.String("key", req.Key), attribute.String("gvk", req.GVK.String())))
 	defer span.End()
 
 	newObj := req.Object

--- a/pkg/router/save.go
+++ b/pkg/router/save.go
@@ -15,7 +15,7 @@ import (
 type save struct {
 	cache   backend.CacheFactory
 	client  kclient.Client
-	tracing tracing.Instrumentation
+	tracing tracing.Tracing
 }
 
 func (s *save) save(unmodified runtime.Object, req Request) (kclient.Object, error) {

--- a/pkg/runtime/backend.go
+++ b/pkg/runtime/backend.go
@@ -11,8 +11,8 @@ import (
 	"github.com/obot-platform/nah/pkg/backend"
 	"github.com/obot-platform/nah/pkg/fields"
 	"github.com/obot-platform/nah/pkg/router"
+	"github.com/obot-platform/nah/pkg/tracing"
 	"github.com/obot-platform/nah/pkg/untriggered"
-	"go.opentelemetry.io/otel"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kcache "k8s.io/client-go/tools/cache"
@@ -23,7 +23,6 @@ import (
 
 var (
 	DefaultThreadiness = 10
-	tracer             = otel.Tracer("nah/runtime")
 )
 
 func init() {
@@ -38,35 +37,37 @@ type Backend struct {
 
 	cacheFactory SharedControllerFactory
 	cache        cache.Cache
+	tracing      tracing.Instrumentation
 	startedLock  *sync.RWMutex
 	started      bool
 }
 
-func newBackend(cacheFactory SharedControllerFactory, client *cacheClient, cache cache.Cache) *Backend {
+func newBackend(cacheFactory SharedControllerFactory, client *cacheClient, cache cache.Cache, instrumentation tracing.Instrumentation) *Backend {
 	return &Backend{
 		cacheClient:  client,
 		cacheFactory: cacheFactory,
 		cache:        cache,
+		tracing:      instrumentation,
 		startedLock:  new(sync.RWMutex),
 	}
 }
 
 func (b *Backend) Start(ctx context.Context) error {
-	ctx, span := tracer.Start(ctx, "start")
+	ctx, span := b.tracing.Start(ctx, "start")
 	defer span.End()
 
 	return b.start(ctx, false)
 }
 
 func (b *Backend) Preload(ctx context.Context) error {
-	ctx, span := tracer.Start(ctx, "preload")
+	ctx, span := b.tracing.Start(ctx, "preload")
 	defer span.End()
 
 	return b.start(ctx, true)
 }
 
 func (b *Backend) start(ctx context.Context, preloadOnly bool) (err error) {
-	ctx, span := tracer.Start(ctx, "start")
+	ctx, span := b.tracing.Start(ctx, "start")
 	defer span.End()
 
 	b.startedLock.Lock()
@@ -144,7 +145,7 @@ func (b *Backend) addIndexer(ctx context.Context, gvk schema.GroupVersionKind) e
 }
 
 func (b *Backend) Watcher(ctx context.Context, gvk schema.GroupVersionKind, name string, cb backend.Callback) error {
-	ctx, span := tracer.Start(ctx, "watcher")
+	ctx, span := b.tracing.Start(ctx, "watcher")
 	defer span.End()
 
 	c, err := b.cacheFactory.ForKind(ctx, gvk)
@@ -180,14 +181,14 @@ func (b *Backend) GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (sche
 }
 
 func (b *Backend) IndexField(ctx context.Context, obj kclient.Object, field string, extractValue kclient.IndexerFunc) error {
-	ctx, span := tracer.Start(ctx, "indexField")
+	ctx, span := b.tracing.StartLevel(ctx, tracing.LevelVerbose, "indexField")
 	defer span.End()
 
 	return b.cache.IndexField(ctx, obj, field, extractValue)
 }
 
 func (b *Backend) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (kcache.SharedIndexInformer, error) {
-	ctx, span := tracer.Start(ctx, "getInformerForKind")
+	ctx, span := b.tracing.StartLevel(ctx, tracing.LevelVerbose, "getInformerForKind")
 	defer span.End()
 
 	i, err := b.cache.GetInformerForKind(ctx, gvk)

--- a/pkg/runtime/backend.go
+++ b/pkg/runtime/backend.go
@@ -37,17 +37,17 @@ type Backend struct {
 
 	cacheFactory SharedControllerFactory
 	cache        cache.Cache
-	tracing      tracing.Instrumentation
+	tracing      tracing.Tracing
 	startedLock  *sync.RWMutex
 	started      bool
 }
 
-func newBackend(cacheFactory SharedControllerFactory, client *cacheClient, cache cache.Cache, instrumentation tracing.Instrumentation) *Backend {
+func newBackend(cacheFactory SharedControllerFactory, client *cacheClient, cache cache.Cache, otelTracing tracing.Tracing) *Backend {
 	return &Backend{
 		cacheClient:  client,
 		cacheFactory: cacheFactory,
 		cache:        cache,
-		tracing:      instrumentation,
+		tracing:      otelTracing,
 		startedLock:  new(sync.RWMutex),
 	}
 }

--- a/pkg/runtime/cached.go
+++ b/pkg/runtime/cached.go
@@ -35,7 +35,7 @@ type objectValue struct {
 type cacheClient struct {
 	uncached kclient.WithWatch
 	cached   kclient.Client
-	tracing  tracing.Instrumentation
+	tracing  tracing.Tracing
 
 	recent     map[objectKey]objectValue
 	recentLock sync.Mutex
@@ -56,11 +56,11 @@ func newer(oldRV, newRV string) bool {
 	return oldI < newI
 }
 
-func newCacheClient(uncached kclient.WithWatch, cached kclient.Client, instrumentation tracing.Instrumentation) *cacheClient {
+func newCacheClient(uncached kclient.WithWatch, cached kclient.Client, otelTracing tracing.Tracing) *cacheClient {
 	return &cacheClient{
 		uncached: uncached,
 		cached:   cached,
-		tracing:  instrumentation,
+		tracing:  otelTracing,
 		recent:   map[objectKey]objectValue{},
 	}
 }

--- a/pkg/runtime/cached.go
+++ b/pkg/runtime/cached.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/obot-platform/nah/pkg/tracing"
 	"github.com/obot-platform/nah/pkg/untriggered"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -34,6 +35,7 @@ type objectValue struct {
 type cacheClient struct {
 	uncached kclient.WithWatch
 	cached   kclient.Client
+	tracing  tracing.Instrumentation
 
 	recent     map[objectKey]objectValue
 	recentLock sync.Mutex
@@ -54,10 +56,11 @@ func newer(oldRV, newRV string) bool {
 	return oldI < newI
 }
 
-func newCacheClient(uncached kclient.WithWatch, cached kclient.Client) *cacheClient {
+func newCacheClient(uncached kclient.WithWatch, cached kclient.Client, instrumentation tracing.Instrumentation) *cacheClient {
 	return &cacheClient{
 		uncached: uncached,
 		cached:   cached,
+		tracing:  instrumentation,
 		recent:   map[objectKey]objectValue{},
 	}
 }
@@ -115,7 +118,7 @@ func (c *cacheClient) store(obj kclient.Object) {
 }
 
 func (c *cacheClient) Get(ctx context.Context, key kclient.ObjectKey, obj kclient.Object, opts ...kclient.GetOption) error {
-	ctx, span := tracer.Start(ctx, "cachedGet")
+	ctx, span := c.tracing.StartLevel(ctx, tracing.LevelVerbose, "cachedGet")
 	defer span.End()
 
 	if u, ok := obj.(*untriggered.Holder); ok {
@@ -160,7 +163,7 @@ func (c *cacheClient) Get(ctx context.Context, key kclient.ObjectKey, obj kclien
 }
 
 func (c *cacheClient) List(ctx context.Context, list kclient.ObjectList, opts ...kclient.ListOption) error {
-	ctx, span := tracer.Start(ctx, "cachedList")
+	ctx, span := c.tracing.StartLevel(ctx, tracing.LevelVerbose, "cachedList")
 	defer span.End()
 
 	if u, ok := list.(*untriggered.HolderList); ok {
@@ -173,7 +176,7 @@ func (c *cacheClient) List(ctx context.Context, list kclient.ObjectList, opts ..
 }
 
 func (c *cacheClient) Create(ctx context.Context, obj kclient.Object, opts ...kclient.CreateOption) error {
-	ctx, span := tracer.Start(ctx, "cachedCreate")
+	ctx, span := c.tracing.StartLevel(ctx, tracing.LevelVerbose, "cachedCreate")
 	defer span.End()
 
 	if u, ok := obj.(*untriggered.Holder); ok {
@@ -191,7 +194,7 @@ func (c *cacheClient) Create(ctx context.Context, obj kclient.Object, opts ...kc
 }
 
 func (c *cacheClient) Delete(ctx context.Context, obj kclient.Object, opts ...kclient.DeleteOption) error {
-	ctx, span := tracer.Start(ctx, "cachedDelete")
+	ctx, span := c.tracing.StartLevel(ctx, tracing.LevelVerbose, "cachedDelete")
 	defer span.End()
 
 	if u, ok := obj.(*untriggered.Holder); ok {
@@ -209,7 +212,7 @@ func (c *cacheClient) Delete(ctx context.Context, obj kclient.Object, opts ...kc
 }
 
 func (c *cacheClient) Update(ctx context.Context, obj kclient.Object, opts ...kclient.UpdateOption) error {
-	ctx, span := tracer.Start(ctx, "cachedUpdate")
+	ctx, span := c.tracing.StartLevel(ctx, tracing.LevelVerbose, "cachedUpdate")
 	defer span.End()
 
 	if u, ok := obj.(*untriggered.Holder); ok {
@@ -227,7 +230,7 @@ func (c *cacheClient) Update(ctx context.Context, obj kclient.Object, opts ...kc
 }
 
 func (c *cacheClient) Patch(ctx context.Context, obj kclient.Object, patch kclient.Patch, opts ...kclient.PatchOption) error {
-	ctx, span := tracer.Start(ctx, "cachedPatch")
+	ctx, span := c.tracing.StartLevel(ctx, tracing.LevelVerbose, "cachedPatch")
 	defer span.End()
 
 	if u, ok := obj.(*untriggered.Holder); ok {
@@ -245,7 +248,7 @@ func (c *cacheClient) Patch(ctx context.Context, obj kclient.Object, patch kclie
 }
 
 func (c *cacheClient) DeleteAllOf(ctx context.Context, obj kclient.Object, opts ...kclient.DeleteAllOfOption) error {
-	ctx, span := tracer.Start(ctx, "cachedDeleteAllOf")
+	ctx, span := c.tracing.StartLevel(ctx, tracing.LevelVerbose, "cachedDeleteAllOf")
 	defer span.End()
 
 	if u, ok := obj.(*untriggered.Holder); ok {
@@ -267,7 +270,7 @@ func (c *cacheClient) SubResource(subResource string) kclient.SubResourceClient 
 }
 
 func (c *cacheClient) Watch(ctx context.Context, obj kclient.ObjectList, opts ...kclient.ListOption) (watch.Interface, error) {
-	ctx, span := tracer.Start(ctx, "cachedWatch")
+	ctx, span := c.tracing.StartLevel(ctx, tracing.LevelVerbose, "cachedWatch")
 	defer span.End()
 
 	return c.uncached.Watch(ctx, obj, opts...)
@@ -295,21 +298,21 @@ type subResourceClient struct {
 }
 
 func (s *subResourceClient) Get(ctx context.Context, obj kclient.Object, subResource kclient.Object, opts ...kclient.SubResourceGetOption) error {
-	ctx, span := tracer.Start(ctx, "subResource/get")
+	ctx, span := s.c.tracing.StartLevel(ctx, tracing.LevelVerbose, "subResource/get")
 	defer span.End()
 
 	return s.reader.Get(ctx, untriggered.Unwrap(obj).(kclient.Object), subResource, opts...)
 }
 
 func (s *subResourceClient) Create(ctx context.Context, obj kclient.Object, subResource kclient.Object, opts ...kclient.SubResourceCreateOption) error {
-	ctx, span := tracer.Start(ctx, "subResource/create")
+	ctx, span := s.c.tracing.StartLevel(ctx, tracing.LevelVerbose, "subResource/create")
 	defer span.End()
 
 	return s.writer.Create(ctx, untriggered.Unwrap(obj).(kclient.Object), subResource, opts...)
 }
 
 func (s *subResourceClient) Update(ctx context.Context, obj kclient.Object, opts ...kclient.SubResourceUpdateOption) error {
-	ctx, span := tracer.Start(ctx, "subResource/update")
+	ctx, span := s.c.tracing.StartLevel(ctx, tracing.LevelVerbose, "subResource/update")
 	defer span.End()
 
 	err := s.writer.Update(ctx, untriggered.Unwrap(obj).(kclient.Object), opts...)
@@ -321,7 +324,7 @@ func (s *subResourceClient) Update(ctx context.Context, obj kclient.Object, opts
 }
 
 func (s *subResourceClient) Patch(ctx context.Context, obj kclient.Object, patch kclient.Patch, opts ...kclient.SubResourcePatchOption) error {
-	ctx, span := tracer.Start(ctx, "subResource/patch")
+	ctx, span := s.c.tracing.StartLevel(ctx, tracing.LevelVerbose, "subResource/patch")
 	defer span.End()
 
 	err := s.writer.Patch(ctx, untriggered.Unwrap(obj).(kclient.Object), patch, opts...)

--- a/pkg/runtime/clients.go
+++ b/pkg/runtime/clients.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/obot-platform/nah/pkg/mapper"
+	"github.com/obot-platform/nah/pkg/tracing"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -40,12 +41,14 @@ func NewRuntimeForNamespace(cfg *rest.Config, namespace string, scheme *runtime.
 }
 
 func NewRuntimeWithConfig(cfg Config, scheme *runtime.Scheme) (*Runtime, error) {
+	instrumentation := tracing.NewInstrumentation("nah/runtime", "")
 	uncachedClient, cachedClient, theCache, err := getClients(cfg, scheme)
 	if err != nil {
 		return nil, err
 	}
 
 	factory := NewSharedControllerFactory(uncachedClient, theCache, &SharedControllerFactoryOptions{
+		Instrumentation:   instrumentation,
 		KindWorkers:       cfg.GVKThreadiness,
 		KindQueueSplitter: cfg.GVKQueueSplitters,
 		// In nah this is only invoked when a key fails to process
@@ -56,7 +59,7 @@ func NewRuntimeWithConfig(cfg Config, scheme *runtime.Scheme) (*Runtime, error) 
 	})
 
 	return &Runtime{
-		Backend: newBackend(factory, newCacheClient(uncachedClient, cachedClient), theCache),
+		Backend: newBackend(factory, newCacheClient(uncachedClient, cachedClient, instrumentation), theCache, instrumentation),
 	}, nil
 }
 

--- a/pkg/runtime/clients.go
+++ b/pkg/runtime/clients.go
@@ -41,14 +41,14 @@ func NewRuntimeForNamespace(cfg *rest.Config, namespace string, scheme *runtime.
 }
 
 func NewRuntimeWithConfig(cfg Config, scheme *runtime.Scheme) (*Runtime, error) {
-	instrumentation := tracing.NewInstrumentation("nah/runtime", "")
+	otelTracing := tracing.New("nah/runtime", "")
 	uncachedClient, cachedClient, theCache, err := getClients(cfg, scheme)
 	if err != nil {
 		return nil, err
 	}
 
 	factory := NewSharedControllerFactory(uncachedClient, theCache, &SharedControllerFactoryOptions{
-		Instrumentation:   instrumentation,
+		Tracing:           otelTracing,
 		KindWorkers:       cfg.GVKThreadiness,
 		KindQueueSplitter: cfg.GVKQueueSplitters,
 		// In nah this is only invoked when a key fails to process
@@ -59,7 +59,7 @@ func NewRuntimeWithConfig(cfg Config, scheme *runtime.Scheme) (*Runtime, error) 
 	})
 
 	return &Runtime{
-		Backend: newBackend(factory, newCacheClient(uncachedClient, cachedClient, instrumentation), theCache, instrumentation),
+		Backend: newBackend(factory, newCacheClient(uncachedClient, cachedClient, otelTracing), theCache, otelTracing),
 	}, nil
 }
 

--- a/pkg/runtime/controller.go
+++ b/pkg/runtime/controller.go
@@ -63,7 +63,7 @@ type controller struct {
 	obj          runtime.Object
 	cache        cache.Cache
 	splitter     WorkerQueueSplitter
-	tracing      tracing.Instrumentation
+	tracing      tracing.Tracing
 }
 
 type startKey struct {
@@ -72,9 +72,9 @@ type startKey struct {
 }
 
 type Options struct {
-	Instrumentation tracing.Instrumentation
-	RateLimiter     workqueue.TypedRateLimiter[any]
-	QueueSplitter   WorkerQueueSplitter
+	Tracing       tracing.Tracing
+	RateLimiter   workqueue.TypedRateLimiter[any]
+	QueueSplitter WorkerQueueSplitter
 }
 
 type WorkerQueueSplitter interface {
@@ -114,7 +114,7 @@ func New(ctx context.Context, gvk schema.GroupVersionKind, scheme *runtime.Schem
 		rateLimiter: opts.RateLimiter,
 		informer:    informer,
 		splitter:    opts.QueueSplitter,
-		tracing:     opts.Instrumentation,
+		tracing:     opts.Tracing,
 	}
 
 	return controller, nil
@@ -133,8 +133,8 @@ func applyDefaultOptions(opts *Options) *Options {
 	if opts != nil {
 		newOpts = *opts
 	}
-	if newOpts.Instrumentation == (tracing.Instrumentation{}) {
-		newOpts.Instrumentation = tracing.NewInstrumentation("nah/runtime", tracing.DefaultLevel)
+	if newOpts.Tracing == (tracing.Tracing{}) {
+		newOpts.Tracing = tracing.New("nah/runtime", "")
 	}
 	if newOpts.RateLimiter == nil {
 		newOpts.RateLimiter = workqueue.NewTypedMaxOfRateLimiter(

--- a/pkg/runtime/controller.go
+++ b/pkg/runtime/controller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/obot-platform/nah/pkg/log"
+	"github.com/obot-platform/nah/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	apierror "k8s.io/apimachinery/pkg/api/errors"
@@ -62,6 +63,7 @@ type controller struct {
 	obj          runtime.Object
 	cache        cache.Cache
 	splitter     WorkerQueueSplitter
+	tracing      tracing.Instrumentation
 }
 
 type startKey struct {
@@ -70,8 +72,9 @@ type startKey struct {
 }
 
 type Options struct {
-	RateLimiter   workqueue.TypedRateLimiter[any]
-	QueueSplitter WorkerQueueSplitter
+	Instrumentation tracing.Instrumentation
+	RateLimiter     workqueue.TypedRateLimiter[any]
+	QueueSplitter   WorkerQueueSplitter
 }
 
 type WorkerQueueSplitter interface {
@@ -111,6 +114,7 @@ func New(ctx context.Context, gvk schema.GroupVersionKind, scheme *runtime.Schem
 		rateLimiter: opts.RateLimiter,
 		informer:    informer,
 		splitter:    opts.QueueSplitter,
+		tracing:     opts.Instrumentation,
 	}
 
 	return controller, nil
@@ -128,6 +132,9 @@ func applyDefaultOptions(opts *Options) *Options {
 	var newOpts Options
 	if opts != nil {
 		newOpts = *opts
+	}
+	if newOpts.Instrumentation == (tracing.Instrumentation{}) {
+		newOpts.Instrumentation = tracing.NewInstrumentation("nah/runtime", tracing.DefaultLevel)
 	}
 	if newOpts.RateLimiter == nil {
 		newOpts.RateLimiter = workqueue.NewTypedMaxOfRateLimiter(
@@ -187,7 +194,7 @@ func (c *controller) run(ctx context.Context, workers int) {
 }
 
 func (c *controller) Start(ctx context.Context, workers int) error {
-	ctx, span := tracer.Start(ctx, "controllerStart", trace.WithAttributes(
+	ctx, span := c.tracing.Start(ctx, "controllerStart", trace.WithAttributes(
 		attribute.String("gvk", c.gvk.String()),
 		attribute.Int("workers", workers),
 	))
@@ -303,10 +310,16 @@ func (c *controller) runWorkers(ctx context.Context, workers int) {
 
 func (c *controller) processSingleItem(ctx context.Context, queue workqueue.TypedRateLimitingInterface[any], obj any) error {
 	// Create a new root span for processing items.
-	ctx, span := tracer.Start(ctx, "processSingleItem", trace.WithNewRoot(), trace.WithAttributes(
-		attribute.String("gvk", c.gvk.String()),
-		attribute.String("key", fmt.Sprintf("%v", obj)),
-	))
+	opts := []trace.SpanStartOption{
+		trace.WithAttributes(
+			attribute.String("gvk", c.gvk.String()),
+			attribute.String("key", fmt.Sprintf("%v", obj)),
+		),
+	}
+	if c.tracing.Level() == tracing.LevelVerbose {
+		opts = append(opts, trace.WithNewRoot())
+	}
+	ctx, span := c.tracing.Start(ctx, "processSingleItem", opts...)
 	defer span.End()
 
 	var (

--- a/pkg/runtime/sharedcontroller.go
+++ b/pkg/runtime/sharedcontroller.go
@@ -42,7 +42,7 @@ type sharedController struct {
 	startError         error
 	client             kclient.Client
 	gvk                schema.GroupVersionKind
-	tracing            tracing.Instrumentation
+	tracing            tracing.Tracing
 }
 
 func (s *sharedController) Cache() (cache.Cache, error) {

--- a/pkg/runtime/sharedcontroller.go
+++ b/pkg/runtime/sharedcontroller.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/obot-platform/nah/pkg/tracing"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -41,6 +42,7 @@ type sharedController struct {
 	startError         error
 	client             kclient.Client
 	gvk                schema.GroupVersionKind
+	tracing            tracing.Instrumentation
 }
 
 func (s *sharedController) Cache() (cache.Cache, error) {
@@ -82,7 +84,7 @@ func (s *sharedController) initController() Controller {
 }
 
 func (s *sharedController) Start(ctx context.Context, workers int) error {
-	ctx, span := tracer.Start(ctx, "sharedControllerStart", trace.WithAttributes(
+	ctx, span := s.tracing.Start(ctx, "sharedControllerStart", trace.WithAttributes(
 		attribute.String("gvk", s.gvk.String()),
 		attribute.Int("workers", workers),
 	))

--- a/pkg/runtime/sharedcontrollerfactory.go
+++ b/pkg/runtime/sharedcontrollerfactory.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"sync"
 
+	"github.com/obot-platform/nah/pkg/tracing"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -24,6 +25,7 @@ type SharedControllerFactoryOptions struct {
 	KindRateLimiter   map[schema.GroupVersionKind]workqueue.TypedRateLimiter[any]
 	KindWorkers       map[schema.GroupVersionKind]int
 	KindQueueSplitter map[schema.GroupVersionKind]WorkerQueueSplitter
+	Instrumentation   tracing.Instrumentation
 }
 
 type sharedControllerFactory struct {
@@ -40,6 +42,7 @@ type sharedControllerFactory struct {
 	kindRateLimiter   map[schema.GroupVersionKind]workqueue.TypedRateLimiter[any]
 	kindWorkers       map[schema.GroupVersionKind]int
 	kindQueueSplitter map[schema.GroupVersionKind]WorkerQueueSplitter
+	instrumentation   tracing.Instrumentation
 }
 
 func NewSharedControllerFactory(c kclient.Client, cache cache.Cache, opts *SharedControllerFactoryOptions) SharedControllerFactory {
@@ -53,6 +56,7 @@ func NewSharedControllerFactory(c kclient.Client, cache cache.Cache, opts *Share
 		rateLimiter:       opts.DefaultRateLimiter,
 		kindRateLimiter:   opts.KindRateLimiter,
 		kindQueueSplitter: opts.KindQueueSplitter,
+		instrumentation:   opts.Instrumentation,
 	}
 }
 
@@ -64,24 +68,27 @@ func applyDefaultSharedOptions(opts *SharedControllerFactoryOptions) *SharedCont
 	if newOpts.DefaultWorkers == 0 {
 		newOpts.DefaultWorkers = DefaultThreadiness
 	}
+	if newOpts.Instrumentation == (tracing.Instrumentation{}) {
+		newOpts.Instrumentation = tracing.NewInstrumentation("nah/runtime", tracing.DefaultLevel)
+	}
 	return &newOpts
 }
 func (s *sharedControllerFactory) Preload(ctx context.Context) error {
-	ctx, span := tracer.Start(ctx, "sharedControllerFactoryPreload")
+	ctx, span := s.instrumentation.Start(ctx, "sharedControllerFactoryPreload")
 	defer span.End()
 
 	return s.loadAndStart(ctx, false)
 }
 
 func (s *sharedControllerFactory) Start(ctx context.Context) error {
-	ctx, span := tracer.Start(ctx, "sharedControllerFactoryStart")
+	ctx, span := s.instrumentation.Start(ctx, "sharedControllerFactoryStart")
 	defer span.End()
 
 	return s.loadAndStart(ctx, true)
 }
 
 func (s *sharedControllerFactory) loadAndStart(ctx context.Context, start bool) error {
-	ctx, span := tracer.Start(ctx, "sharedControllerFactoryLoadAndStart")
+	ctx, span := s.instrumentation.Start(ctx, "sharedControllerFactoryLoadAndStart")
 	defer span.End()
 
 	s.controllerLock.Lock()
@@ -150,13 +157,15 @@ func (s *sharedControllerFactory) ForKind(ctx context.Context, gvk schema.GroupV
 			}
 
 			return New(ctx, gvk, s.client.Scheme(), s.cache, handler, &Options{
-				RateLimiter:   rateLimiter,
-				QueueSplitter: s.kindQueueSplitter[gvk],
+				Instrumentation: s.instrumentation,
+				RateLimiter:     rateLimiter,
+				QueueSplitter:   s.kindQueueSplitter[gvk],
 			})
 		},
 		handler: handler,
 		client:  s.client,
 		gvk:     gvk,
+		tracing: s.instrumentation,
 	}
 
 	s.controllers[gvk] = controllerResult

--- a/pkg/runtime/sharedcontrollerfactory.go
+++ b/pkg/runtime/sharedcontrollerfactory.go
@@ -25,7 +25,7 @@ type SharedControllerFactoryOptions struct {
 	KindRateLimiter   map[schema.GroupVersionKind]workqueue.TypedRateLimiter[any]
 	KindWorkers       map[schema.GroupVersionKind]int
 	KindQueueSplitter map[schema.GroupVersionKind]WorkerQueueSplitter
-	Instrumentation   tracing.Instrumentation
+	Tracing           tracing.Tracing
 }
 
 type sharedControllerFactory struct {
@@ -42,7 +42,7 @@ type sharedControllerFactory struct {
 	kindRateLimiter   map[schema.GroupVersionKind]workqueue.TypedRateLimiter[any]
 	kindWorkers       map[schema.GroupVersionKind]int
 	kindQueueSplitter map[schema.GroupVersionKind]WorkerQueueSplitter
-	instrumentation   tracing.Instrumentation
+	tracing           tracing.Tracing
 }
 
 func NewSharedControllerFactory(c kclient.Client, cache cache.Cache, opts *SharedControllerFactoryOptions) SharedControllerFactory {
@@ -56,7 +56,7 @@ func NewSharedControllerFactory(c kclient.Client, cache cache.Cache, opts *Share
 		rateLimiter:       opts.DefaultRateLimiter,
 		kindRateLimiter:   opts.KindRateLimiter,
 		kindQueueSplitter: opts.KindQueueSplitter,
-		instrumentation:   opts.Instrumentation,
+		tracing:           opts.Tracing,
 	}
 }
 
@@ -68,27 +68,27 @@ func applyDefaultSharedOptions(opts *SharedControllerFactoryOptions) *SharedCont
 	if newOpts.DefaultWorkers == 0 {
 		newOpts.DefaultWorkers = DefaultThreadiness
 	}
-	if newOpts.Instrumentation == (tracing.Instrumentation{}) {
-		newOpts.Instrumentation = tracing.NewInstrumentation("nah/runtime", tracing.DefaultLevel)
+	if newOpts.Tracing == (tracing.Tracing{}) {
+		newOpts.Tracing = tracing.New("nah/runtime", "")
 	}
 	return &newOpts
 }
 func (s *sharedControllerFactory) Preload(ctx context.Context) error {
-	ctx, span := s.instrumentation.Start(ctx, "sharedControllerFactoryPreload")
+	ctx, span := s.tracing.Start(ctx, "sharedControllerFactoryPreload")
 	defer span.End()
 
 	return s.loadAndStart(ctx, false)
 }
 
 func (s *sharedControllerFactory) Start(ctx context.Context) error {
-	ctx, span := s.instrumentation.Start(ctx, "sharedControllerFactoryStart")
+	ctx, span := s.tracing.Start(ctx, "sharedControllerFactoryStart")
 	defer span.End()
 
 	return s.loadAndStart(ctx, true)
 }
 
 func (s *sharedControllerFactory) loadAndStart(ctx context.Context, start bool) error {
-	ctx, span := s.instrumentation.Start(ctx, "sharedControllerFactoryLoadAndStart")
+	ctx, span := s.tracing.Start(ctx, "sharedControllerFactoryLoadAndStart")
 	defer span.End()
 
 	s.controllerLock.Lock()
@@ -157,15 +157,15 @@ func (s *sharedControllerFactory) ForKind(ctx context.Context, gvk schema.GroupV
 			}
 
 			return New(ctx, gvk, s.client.Scheme(), s.cache, handler, &Options{
-				Instrumentation: s.instrumentation,
-				RateLimiter:     rateLimiter,
-				QueueSplitter:   s.kindQueueSplitter[gvk],
+				Tracing:       s.tracing,
+				RateLimiter:   rateLimiter,
+				QueueSplitter: s.kindQueueSplitter[gvk],
 			})
 		},
 		handler: handler,
 		client:  s.client,
 		gvk:     gvk,
-		tracing: s.instrumentation,
+		tracing: s.tracing,
 	}
 
 	s.controllers[gvk] = controllerResult

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -1,0 +1,98 @@
+package tracing
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+type Level string
+
+const (
+	LevelOff     Level = "off"
+	LevelBasic   Level = "basic"
+	LevelVerbose Level = "verbose"
+	EnvVarName         = "NAH_TRACE_LEVEL"
+
+	DefaultLevel = LevelOff
+)
+
+func (l Level) normalized() Level {
+	switch l {
+	case LevelOff, LevelBasic, LevelVerbose:
+		return l
+	case "":
+		if envLevel, ok := LevelFromEnv(); ok {
+			return envLevel
+		}
+		return DefaultLevel
+	default:
+		return DefaultLevel
+	}
+}
+
+func ParseLevel(value string) (Level, bool) {
+	switch Level(strings.ToLower(strings.TrimSpace(value))) {
+	case LevelOff:
+		return LevelOff, true
+	case LevelBasic:
+		return LevelBasic, true
+	case LevelVerbose:
+		return LevelVerbose, true
+	default:
+		return "", false
+	}
+}
+
+func LevelFromEnv() (Level, bool) {
+	return ParseLevel(os.Getenv(EnvVarName))
+}
+
+func (l Level) Enabled(min Level) bool {
+	return levelRank(l.normalized()) >= levelRank(min.normalized())
+}
+
+func levelRank(l Level) int {
+	switch l {
+	case LevelVerbose:
+		return 2
+	case LevelBasic:
+		return 1
+	default:
+		return 0
+	}
+}
+
+type Instrumentation struct {
+	tracer trace.Tracer
+	level  Level
+}
+
+func NewInstrumentation(scope string, level Level) Instrumentation {
+	return Instrumentation{
+		tracer: otel.Tracer(scope),
+		level:  level.normalized(),
+	}
+}
+
+func (i Instrumentation) Level() Level {
+	return i.level.normalized()
+}
+
+func (i Instrumentation) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return i.StartLevel(ctx, LevelBasic, name, opts...)
+}
+
+func (i Instrumentation) StartLevel(ctx context.Context, min Level, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	if !i.Level().Enabled(min) {
+		return ctx, noop.Span{}
+	}
+	if i.tracer == nil {
+		return ctx, noop.Span{}
+	}
+	return i.tracer.Start(ctx, name, opts...)
+}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -16,9 +16,9 @@ const (
 	LevelOff     Level = "off"
 	LevelBasic   Level = "basic"
 	LevelVerbose Level = "verbose"
-	EnvVarName         = "NAH_TRACE_LEVEL"
 
-	DefaultLevel = LevelOff
+	envVarName   = "NAH_TRACE_LEVEL"
+	defaultLevel = LevelOff
 )
 
 func (l Level) normalized() Level {
@@ -29,9 +29,9 @@ func (l Level) normalized() Level {
 		if envLevel, ok := LevelFromEnv(); ok {
 			return envLevel
 		}
-		return DefaultLevel
+		return defaultLevel
 	default:
-		return DefaultLevel
+		return defaultLevel
 	}
 }
 
@@ -49,7 +49,7 @@ func ParseLevel(value string) (Level, bool) {
 }
 
 func LevelFromEnv() (Level, bool) {
-	return ParseLevel(os.Getenv(EnvVarName))
+	return ParseLevel(os.Getenv(envVarName))
 }
 
 func (l Level) Enabled(min Level) bool {
@@ -67,32 +67,32 @@ func levelRank(l Level) int {
 	}
 }
 
-type Instrumentation struct {
+type Tracing struct {
 	tracer trace.Tracer
 	level  Level
 }
 
-func NewInstrumentation(scope string, level Level) Instrumentation {
-	return Instrumentation{
+func New(scope string, level Level) Tracing {
+	return Tracing{
 		tracer: otel.Tracer(scope),
 		level:  level.normalized(),
 	}
 }
 
-func (i Instrumentation) Level() Level {
-	return i.level.normalized()
+func (t Tracing) Level() Level {
+	return t.level.normalized()
 }
 
-func (i Instrumentation) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return i.StartLevel(ctx, LevelBasic, name, opts...)
+func (t Tracing) Start(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return t.StartLevel(ctx, LevelBasic, name, opts...)
 }
 
-func (i Instrumentation) StartLevel(ctx context.Context, min Level, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	if !i.Level().Enabled(min) {
+func (t Tracing) StartLevel(ctx context.Context, min Level, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	if !t.Level().Enabled(min) {
 		return ctx, noop.Span{}
 	}
-	if i.tracer == nil {
+	if t.tracer == nil {
 		return ctx, noop.Span{}
 	}
-	return i.tracer.Start(ctx, name, opts...)
+	return t.tracer.Start(ctx, name, opts...)
 }


### PR DESCRIPTION

  Add internal trace-level control for nah using
  NAH_TRACE_LEVEL=off|basic|verbose.

  Keep only higher-value spans at basic, preserve the more detailed
  instrumentation at verbose, and disable nah's internal tracing by
  default when the env var is unset.

  This also removes the public trace-level API surface so tracing
  behavior is configured only through the environment.