### PR TITLE
fix: force JSON for nah leader election lease clients

### DIFF
--- a/pkg/leader/leader.go
+++ b/pkg/leader/leader.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/obot-platform/nah/pkg/leader/locks"
 	"github.com/obot-platform/nah/pkg/log"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -105,7 +106,7 @@ func (ec *ElectionConfig) run(ctx context.Context, id string, cb OnLeader, onSwi
 			resourcelock.ResourceLockConfig{
 				Identity: id,
 			},
-			ec.restCfg,
+			jsonClientConfig(ec.restCfg),
 			ec.TTL/2,
 		)
 	}
@@ -147,4 +148,11 @@ func (ec *ElectionConfig) run(ctx context.Context, id string, cb OnLeader, onSwi
 		le.Run(ctx)
 	}()
 	return nil
+}
+
+func jsonClientConfig(cfg *rest.Config) *rest.Config {
+	cfg = rest.CopyConfig(cfg)
+	cfg.AcceptContentTypes = runtime.ContentTypeJSON
+	cfg.ContentType = runtime.ContentTypeJSON
+	return cfg
 }

--- a/pkg/leader/leader_test.go
+++ b/pkg/leader/leader_test.go
@@ -1,0 +1,36 @@
+package leader
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+)
+
+func TestJSONClientConfigForcesJSONContentNegotiation(t *testing.T) {
+	original := &rest.Config{
+		Host: "https://example.invalid",
+		ContentConfig: rest.ContentConfig{
+			AcceptContentTypes: "application/vnd.kubernetes.protobuf,application/json",
+			ContentType:        "application/vnd.kubernetes.protobuf",
+		},
+	}
+
+	cfg := jsonClientConfig(original)
+
+	if cfg == original {
+		t.Fatal("expected a copied config")
+	}
+	if cfg.AcceptContentTypes != runtime.ContentTypeJSON {
+		t.Fatalf("expected accept content types %q, got %q", runtime.ContentTypeJSON, cfg.AcceptContentTypes)
+	}
+	if cfg.ContentType != runtime.ContentTypeJSON {
+		t.Fatalf("expected content type %q, got %q", runtime.ContentTypeJSON, cfg.ContentType)
+	}
+	if original.AcceptContentTypes != "application/vnd.kubernetes.protobuf,application/json" {
+		t.Fatalf("expected original accept content types to remain unchanged, got %q", original.AcceptContentTypes)
+	}
+	if original.ContentType != "application/vnd.kubernetes.protobuf" {
+		t.Fatalf("expected original content type to remain unchanged, got %q", original.ContentType)
+	}
+}


### PR DESCRIPTION
> Note from Grant: this is an AI-generated summary. These nah changes were necessary due to updates to Kubernetes dependencies, that I believe came with the introduction of Helm in some upcoming Obot changes I am working on. This was necessary in order to keep leader election functional.

## Summary

This changes nah leader election to force JSON content negotiation when creating the client-go resource lock client.

Without this, leader election can fail against API servers that intentionally do not support protobuf request bodies, even though the rest of the controller stack works correctly with JSON.

### Why this is necessary

nah uses client-go leader election with a coordination.k8s.io/v1 Lease lock. In newer client-go releases, the generated Lease client prefers protobuf by default.

That becomes a problem for Obot storage, which is backed by kinm. kinm explicitly disables protobuf for API groups and only accepts JSON/YAML request bodies. As a result, leader election attempts fail with errors like:

error initially creating leader election record: the body of the request was in an unknown format - accepted media types include: application/json, application/yaml

This broke both:

- Obot’s own HA controller leader election
- the aviatrix network policy controller when it uses Obot storage as its API backend

So the issue is not that leader election is wrong in principle. The issue is that the generated Lease client now prefers a wire format that this API server intentionally does not serve.

## What this change does

Before constructing the client-go resource lock, nah now copies the provided rest.Config and forces:

- AcceptContentTypes = application/json
- ContentType = application/json

That keeps leader election on the normal Lease API path, but ensures the lock client uses a format the server actually supports.

## Why this is the right fix

- It preserves multi-replica / HA behavior.
- It fixes the issue at the shared leader-election layer instead of disabling election in downstream controllers.
- It is narrow in scope: only the leader-election lock client is forced to JSON.
- It avoids depending on protobuf support from non-Kubernetes API servers that intentionally omit it.